### PR TITLE
Update tile server address

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
             vector_layer_: {
               type: "vector",
               tiles: [
-                "https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/v3/{z}/{x}/{y}.pbf",
+                "https://tile.ourmap.us/data/v3/{z}/{x}/{y}.pbf",
               ],
               minzoom: 0,
               maxzoom: 14,


### PR DESCRIPTION
I've changed my tile server off of the AWS addressing scheme in order to save on hosting costs (eliminate AWS's proxy https service).