### PR TITLE
Update vector tile source URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
             vector_layer_: {
               type: "vector",
               tiles: [
-                "https://dwuxtsziek7cf.cloudfront.net/planet/{z}/{x}/{y}.mvt",
+                "https://tiles.openstreetmap.us/vector/openmaptiles/{z}/{x}/{y}.mvt",
               ],
               minzoom: 0,
               maxzoom: 14,


### PR DESCRIPTION
The OSM US Tileservice has moved from AWS to Cloudflare, and the AWS Cloudfront URL that is currently hardcoded in this repo is no longer active. This PR switches it to use the supported [tiles.openstreetmap.us](https://tiles.openstreetmap.us/) URL which will continue to work in the future even if the underlying cloud infrastructure changes again.